### PR TITLE
Switch to hook-based implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Resubscribe is a React utility that renders asynchronous values.
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
 ## Table of Contents
 
 - [Installation](#installation)
@@ -28,10 +29,11 @@ npm install resubscribe
 ## Supported Concepts
 
 The following asynchronous concepts are supported out-of-the-box:
+
 - [Promises](https://promisesaplus.com/)
 - [Observables](https://github.com/tc39/proposal-observable)
 - [Async Iterators](https://github.com/tc39/proposal-async-iteration)
--  synchronous values
+- synchronous values
 
 ## Usage
 
@@ -43,6 +45,15 @@ The `<Subscribe />`-component needs a source to subscribe to - whch can be [anyt
 <Subscribe to={source}>
   {value => <div>{value}</div>}
 </Subscribe>
+```
+
+Additionally, a `useSubscribable` hook is provided, so you don't have to rely on the render prop implementation:
+
+```
+const state = useSubscribable(source)
+if (state.kind === 'loading') return 'Loading'
+if (state.kind === 'error') return 'error'
+if (state.kind === 'next') return 'Value: ' + state.value
 ```
 
 ### With Promises
@@ -88,7 +99,7 @@ const asyncIterator = (async function*() {
     // sleep for one second
     await new Promise(resolve => setTimeout(resolve, 1000))
   }
-})
+})()
 
 // renders <div>X</div>
 // X starts at 0 and is incremented every second
@@ -137,6 +148,7 @@ const promise = new Promise((resolve, reject) => {
 ```
 
 All renderer methods are optional and have the following defaults:
+
 - `loading`: Render the placeholder, or nothing if it does not exist.
 - `next`: Identity, i.e. render the value as-is.
 - `error`: Render nothing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -215,15 +215,18 @@
       }
     },
     "@types/cheerio": {
-      "version": "0.22.10",
-      "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.10.tgz",
-      "integrity": "sha512-fOM/Jhv51iyugY7KOBZz2ThfT1gwvsGCfWxpLpZDgkGjpEO4Le9cld07OdskikLjDUQJ43dzDaVRSFwQlpdqVg==",
-      "dev": true
+      "version": "0.22.13",
+      "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.13.tgz",
+      "integrity": "sha512-OZd7dCUOUkiTorf97vJKwZnSja/DmHfuBAroe1kREZZTCf/tlFecwHhsOos3uVHxeKGZDwzolIrCUApClkdLuA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/enzyme": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.9.0.tgz",
-      "integrity": "sha512-o0C7ooyBtj9NKyMzn2BWN53W4J21KPhO+/v+qqQX28Pcz0Z1B3DjL9bq2ZR4TN70PVw8O7gkhuFtC7VN3tausg==",
+      "version": "3.10.3",
+      "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.10.3.tgz",
+      "integrity": "sha512-f/Kcb84sZOSZiBPCkr4He9/cpuSLcKRyQaEE20Q30Prx0Dn6wcyMAWI0yofL6yvd9Ht9G7EVkQeRqK0n5w8ILw==",
       "dev": true,
       "requires": {
         "@types/cheerio": "*",
@@ -273,9 +276,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "16.8.6",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.6.tgz",
-      "integrity": "sha512-bN9qDjEMltmHrl0PZRI4IF2AbB7V5UlRfG+OOduckVnRQ4VzXVSzy/1eLAh778IEqhTnW0mmgL9yShfinNverA==",
+      "version": "16.9.4",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.4.tgz",
+      "integrity": "sha512-ItGNmJvQ0IvWt8rbk5PLdpdQhvBVxAaXI9hDlx7UMd8Ie1iMIuwMNiKeTfmVN517CdplpyXvA22X4zm4jGGZnw==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -283,9 +286,9 @@
       }
     },
     "@types/react-dom": {
-      "version": "16.8.2",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.8.2.tgz",
-      "integrity": "sha512-MX7n1wq3G/De15RGAAqnmidzhr2Y9O/ClxPxyqaNg96pGyeXUYPSvujgzEVpLo9oIP4Wn1UETl+rxTN02KEpBw==",
+      "version": "16.9.1",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.1.tgz",
+      "integrity": "sha512-1S/akvkKr63qIUWVu5IKYou2P9fHLb/P2VAwyxVV85JGaGZTcUniMiTuIqM3lXFB25ej6h+CYEQ27ERVwi6eGA==",
       "dev": true,
       "requires": {
         "@types/react": "*"
@@ -326,6 +329,44 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
       "integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
       "dev": true
+    },
+    "airbnb-prop-types": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.15.0.tgz",
+      "integrity": "sha512-jUh2/hfKsRjNFC4XONQrxo/n/3GG4Tn6Hl0WlFQN5PY9OMC9loSCoAYKnZsWaP8wEfd5xcrPloK0Zg6iS1xwVA==",
+      "dev": true,
+      "requires": {
+        "array.prototype.find": "^2.1.0",
+        "function.prototype.name": "^1.1.1",
+        "has": "^1.0.3",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.1.0",
+        "prop-types": "^15.7.2",
+        "prop-types-exact": "^1.2.0",
+        "react-is": "^16.9.0"
+      },
+      "dependencies": {
+        "function.prototype.name": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.1.tgz",
+          "integrity": "sha512-e1NzkiJuw6xqVH7YSdiW/qDHebcmMhPNe6w+4ZYYEg0VA+LaLzx37RimbPLuonHhYGFGPx1ME2nSi74JiaCr/Q==",
+          "dev": true,
+          "requires": {
+            "define-properties": "^1.1.3",
+            "function-bind": "^1.1.1",
+            "functions-have-names": "^1.1.1",
+            "is-callable": "^1.1.4"
+          }
+        },
+        "react-is": {
+          "version": "16.10.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.1.tgz",
+          "integrity": "sha512-BXUMf9sIOPXXZWqr7+c5SeOKJykyVr2u0UDzEf4LNGc6taGkQe1A9DFD07umCIXz45RLr9oAAwZbAJ0Pkknfaw==",
+          "dev": true
+        }
+      }
     },
     "ajv": {
       "version": "6.10.0",
@@ -438,6 +479,16 @@
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
+    },
+    "array.prototype.find": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.0.tgz",
+      "integrity": "sha512-Wn41+K1yuO5p7wRZDl7890c3xvv5UBrfVXTVIe28rSQb6LS0fZMDrQB6PAcxQFRFy6vJTLDc3A2+3CjQdzVKRg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.13.0"
+      }
     },
     "array.prototype.flat": {
       "version": "1.2.1",
@@ -932,13 +983,13 @@
       "dev": true
     },
     "cheerio": {
-      "version": "1.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
-      "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
+      "integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
       "dev": true,
       "requires": {
         "css-select": "~1.2.0",
-        "dom-serializer": "~0.1.0",
+        "dom-serializer": "~0.1.1",
         "entities": "~1.1.1",
         "htmlparser2": "^3.9.1",
         "lodash": "^4.15.0",
@@ -1076,9 +1127,9 @@
       }
     },
     "commander": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.1.tgz",
+      "integrity": "sha512-cCuLsMhJeWQ/ZpsFTbE765kvVfoeSddc4nU3up4fV+fDBcfUXnbITJ+JzhkdjzOqhURjZgujxaioam4RM9yGUg==",
       "dev": true
     },
     "compare-versions": {
@@ -1179,9 +1230,9 @@
       }
     },
     "csstype": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.2.tgz",
-      "integrity": "sha512-Rl7PvTae0pflc1YtxtKbiSqq20Ts6vpIYOD5WBafl4y123DyHUeLrRdQP66sQW8/6gmX8jrYJLXwNeMqYVJcow==",
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.6.tgz",
+      "integrity": "sha512-RpFbQGUE74iyPgvr46U9t1xoQBM8T4BL8SxrN66Le2xYAPSaDJJKeztV3awugusb3g3G9iL8StmkBBXhcbbXhg==",
       "dev": true
     },
     "currently-unhandled": {
@@ -1365,7 +1416,8 @@
     },
     "discontinuous-range": {
       "version": "1.0.0",
-      "resolved": "github:fent/discontinuous-range#a4c2462c6ee92c6f995e89c6b020a2eeec4183e6",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=",
       "dev": true
     },
     "doctoc": {
@@ -1458,9 +1510,9 @@
       "dev": true
     },
     "enzyme": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.9.0.tgz",
-      "integrity": "sha512-JqxI2BRFHbmiP7/UFqvsjxTirWoM1HfeaJrmVSZ9a1EADKkZgdPcAuISPMpoUiHlac9J4dYt81MC5BBIrbJGMg==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.10.0.tgz",
+      "integrity": "sha512-p2yy9Y7t/PFbPoTvrWde7JIYB2ZyGC+NgTNbVEGvZ5/EyoYSr9aG/2rSbVvyNvMHEhw9/dmGUJHWtfQIEiX9pg==",
       "dev": true,
       "requires": {
         "array.prototype.flat": "^1.2.1",
@@ -1487,29 +1539,46 @@
       }
     },
     "enzyme-adapter-react-16": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.10.0.tgz",
-      "integrity": "sha512-0QqwEZcBv1xEEla+a3H7FMci+y4ybLia9cZzsdIrId7qcig4MK0kqqf6iiCILH1lsKS6c6AVqL3wGPhCevv5aQ==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.14.0.tgz",
+      "integrity": "sha512-7PcOF7pb4hJUvjY7oAuPGpq3BmlCig3kxXGi2kFx0YzJHppqX1K8IIV9skT1IirxXlu8W7bneKi+oQ10QRnhcA==",
       "dev": true,
       "requires": {
-        "enzyme-adapter-utils": "^1.10.0",
+        "enzyme-adapter-utils": "^1.12.0",
+        "has": "^1.0.3",
         "object.assign": "^4.1.0",
         "object.values": "^1.1.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.7.0",
-        "react-test-renderer": "^16.0.0-0"
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.6",
+        "react-test-renderer": "^16.0.0-0",
+        "semver": "^5.7.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.10.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.1.tgz",
+          "integrity": "sha512-BXUMf9sIOPXXZWqr7+c5SeOKJykyVr2u0UDzEf4LNGc6taGkQe1A9DFD07umCIXz45RLr9oAAwZbAJ0Pkknfaw==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "enzyme-adapter-utils": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.10.0.tgz",
-      "integrity": "sha512-VnIXJDYVTzKGbdW+lgK8MQmYHJquTQZiGzu/AseCZ7eHtOMAj4Rtvk8ZRopodkfPves0EXaHkXBDkVhPa3t0jA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.12.0.tgz",
+      "integrity": "sha512-wkZvE0VxcFx/8ZsBw0iAbk3gR1d9hK447ebnSYBf95+r32ezBq+XDSAvRErkc4LZosgH8J7et7H7/7CtUuQfBA==",
       "dev": true,
       "requires": {
+        "airbnb-prop-types": "^2.13.2",
         "function.prototype.name": "^1.1.0",
         "object.assign": "^4.1.0",
         "object.fromentries": "^2.0.0",
-        "prop-types": "^15.6.2",
+        "prop-types": "^15.7.2",
         "semver": "^5.6.0"
       }
     },
@@ -2026,8 +2095,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2048,14 +2116,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2070,20 +2136,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2200,8 +2263,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2213,7 +2275,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2228,7 +2289,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2236,14 +2296,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2262,7 +2320,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2343,8 +2400,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2356,7 +2412,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2442,8 +2497,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2479,7 +2533,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2499,7 +2552,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2543,14 +2595,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -2570,6 +2620,12 @@
         "function-bind": "^1.1.1",
         "is-callable": "^1.1.3"
       }
+    },
+    "functions-have-names": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.1.1.tgz",
+      "integrity": "sha512-U0kNHUoxwPNPWOJaMG7Z00d4a/qZVrFtzWJRaK8V9goaVOCXBSQSJpt3MYGNtkScKEBKovxLjnNdC9MlXwo5Pw==",
+      "dev": true
     },
     "get-caller-file": {
       "version": "1.0.3",
@@ -2748,9 +2804,9 @@
       "dev": true
     },
     "html-element-map": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.0.0.tgz",
-      "integrity": "sha512-/SP6aOiM5Ai9zALvCxDubIeez0LvG3qP7R9GcRDnJEP/HBmv0A8A9K0o8+HFudcFt46+i921ANjzKsjPjb7Enw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.1.0.tgz",
+      "integrity": "sha512-iqiG3dTZmy+uUaTmHarTL+3/A2VW9ox/9uasKEZC+R/wAtUrTcRlXPSaPqsnWPfIu8wqn09jQNwMRqzL54jSYA==",
       "dev": true,
       "requires": {
         "array-filter": "^1.0.0"
@@ -4320,9 +4376,9 @@
       "dev": true
     },
     "nearley": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.16.0.tgz",
-      "integrity": "sha512-Tr9XD3Vt/EujXbZBv6UAHYoLUSMQAxSsTnm9K3koXzjzNWY195NqALeyrzLZBKzAkL3gl92BcSogqrHjD8QuUg==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.19.0.tgz",
+      "integrity": "sha512-2v52FTw7RPqieZr3Gth1luAXZR7Je6q3KaDHY5bjl/paDUdMu35fZ8ICNgiYJRr3tf3NMvIQQR1r27AvEr9CRA==",
       "dev": true,
       "requires": {
         "commander": "^2.19.0",
@@ -4987,6 +5043,17 @@
         "react-is": "^16.8.1"
       }
     },
+    "prop-types-exact": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/prop-types-exact/-/prop-types-exact-1.2.0.tgz",
+      "integrity": "sha512-K+Tk3Kd9V0odiXFP9fwDHUYRyvK3Nun3GVyPapSIs5OBkITAm15W0CPFD/YKTkMUAbc0b9CUwRQp2ybiBIq+eA==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3",
+        "object.assign": "^4.1.0",
+        "reflect.ownkeys": "^0.2.0"
+      }
+    },
     "psl": {
       "version": "1.1.31",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
@@ -5066,27 +5133,26 @@
       }
     },
     "react": {
-      "version": "16.8.3",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.8.3.tgz",
-      "integrity": "sha512-3UoSIsEq8yTJuSu0luO1QQWYbgGEILm+eJl2QN/VLDi7hL+EN18M3q3oVZwmVzzBJ3DkM7RMdRwBmZZ+b4IzSA==",
+      "version": "16.10.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.10.1.tgz",
+      "integrity": "sha512-2bisHwMhxQ3XQz4LiJJwG3360pY965pTl/MRrZYxIBKVj4fOHoDs5aZAkYXGxDRO1Li+SyjTAilQEbOmtQJHzA==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.13.3"
+        "prop-types": "^15.6.2"
       }
     },
     "react-dom": {
-      "version": "16.8.3",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.3.tgz",
-      "integrity": "sha512-ttMem9yJL4/lpItZAQ2NTFAbV7frotHk5DZEHXUOws2rMmrsvh1Na7ThGT0dTzUIl6pqTOi5tYREfL8AEna3lA==",
+      "version": "16.10.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.10.1.tgz",
+      "integrity": "sha512-SmM4ZW0uug0rn95U8uqr52I7UdNf6wdGLeXDmNLfg3y5q5H9eAbdjF5ubQc3bjDyRrvdAB2IKG7X0GzSpnn5Mg==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.13.3"
+        "scheduler": "^0.16.1"
       }
     },
     "react-is": {
@@ -5095,15 +5161,33 @@
       "integrity": "sha512-Y4rC1ZJmsxxkkPuMLwvKvlL1Zfpbcu+Bf4ZigkHup3v9EfdYhAlWAaVyA19olXq2o2mGn0w+dFKvk3pVVlYcIA=="
     },
     "react-test-renderer": {
-      "version": "16.8.3",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.8.3.tgz",
-      "integrity": "sha512-rjJGYebduKNZH0k1bUivVrRLX04JfIQ0FKJLPK10TAb06XWhfi4gTobooF9K/DEFNW98iGac3OSxkfIJUN9Mdg==",
+      "version": "16.10.1",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.10.1.tgz",
+      "integrity": "sha512-VT8nd7XrrUV7MQPxeIuH7WstfrK2A8kgcMwGUtVXa0ja+CiYkxdmLYNjwX1L7irRF7ydzJJWiSLsQf2xBj4Xaw==",
       "dev": true,
       "requires": {
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "react-is": "^16.8.3",
-        "scheduler": "^0.13.3"
+        "react-is": "^16.8.6",
+        "scheduler": "^0.16.1"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.10.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.1.tgz",
+          "integrity": "sha512-BXUMf9sIOPXXZWqr7+c5SeOKJykyVr2u0UDzEf4LNGc6taGkQe1A9DFD07umCIXz45RLr9oAAwZbAJ0Pkknfaw==",
+          "dev": true
+        },
+        "scheduler": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.16.1.tgz",
+          "integrity": "sha512-MIuie7SgsqMYOdCXVFZa8SKoNorJZUWHW8dPgto7uEHn1lX3fg2Gu0TzgK8USj76uxV7vB5eRMnZs/cdEHg+cg==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "read-pkg": {
@@ -5205,6 +5289,12 @@
         "indent-string": "^3.0.0",
         "strip-indent": "^2.0.0"
       }
+    },
+    "reflect.ownkeys": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
+      "integrity": "sha1-dJrO7H8/34tj+SegSAnpDFwLNGA=",
+      "dev": true
     },
     "regex-cache": {
       "version": "0.4.4",
@@ -5630,9 +5720,9 @@
       "dev": true
     },
     "scheduler": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.3.tgz",
-      "integrity": "sha512-UxN5QRYWtpR1egNWzJcVLk8jlegxAugswQc984lD3kU7NuobsO37/sRfbpTdBjtnD5TBNFA2Q2oLV5+UmPSmEQ==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.16.1.tgz",
+      "integrity": "sha512-MIuie7SgsqMYOdCXVFZa8SKoNorJZUWHW8dPgto7uEHn1lX3fg2Gu0TzgK8USj76uxV7vB5eRMnZs/cdEHg+cg==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
@@ -6021,14 +6111,14 @@
       }
     },
     "string.prototype.trim": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
-      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.0.tgz",
+      "integrity": "sha512-9EIjYD/WdlvLpn987+ctkLf0FfvBefOCuiEr2henD8X+7jfwPnyvTdmW8OJhj5p+M0/96mBdynLWkxUr+rHlpg==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.0",
-        "function-bind": "^1.0.2"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.13.0",
+        "function-bind": "^1.1.1"
       }
     },
     "string_decoder": {

--- a/package.json
+++ b/package.json
@@ -8,19 +8,19 @@
   },
   "description": "Render asynchronous values with React",
   "devDependencies": {
-    "@types/enzyme": "^3.9.0",
+    "@types/enzyme": "^3.10.3",
     "@types/enzyme-adapter-react-16": "^1.0.5",
     "@types/jest": "^24.0.9",
     "@types/prop-types": "^15.7.0",
-    "@types/react": "^16.8.6",
-    "@types/react-dom": "^16.8.2",
+    "@types/react": "^16.9.4",
+    "@types/react-dom": "^16.9.1",
     "doctoc": "^1.4.0",
-    "enzyme": "^3.9.0",
-    "enzyme-adapter-react-16": "^1.10.0",
+    "enzyme": "^3.10.0",
+    "enzyme-adapter-react-16": "^1.14.0",
     "jest": "^24.1.0",
     "npm-scripts-info": "^0.3.9",
-    "react": "^16.8.3",
-    "react-dom": "^16.8.3",
+    "react": "^16.10.1",
+    "react-dom": "^16.10.1",
     "rimraf": "^2.6.3",
     "rollup": "^1.4.1",
     "rollup-plugin-typescript2": "^0.19.3",
@@ -38,7 +38,7 @@
   "name": "resubscribe",
   "license": "MIT",
   "peerDependencies": {
-    "react": "16.x.x"
+    "react": "^16.8.0"
   },
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from './Subscribe'
+export * from './useSubscribable'

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -1,9 +1,11 @@
+import {Observable as RXObservabje} from 'rxjs'
+
 import {Observable} from './Observable'
 
 /**
  * Something that can be subscribed to.
  */
-type Subscribable<T> = Observable<T> | Promise<T> | AsyncIterator<T> | T
+type Subscribable<T> = RXObservabje<T> | Observable<T> | Promise<T> | AsyncIterator<T> | T
 
 /**
  * A subscription than can be unsubscribed from.

--- a/src/useSubscribable.ts
+++ b/src/useSubscribable.ts
@@ -1,0 +1,25 @@
+import {useState, useEffect} from 'react'
+
+import {Subscribable} from './internal/types'
+import {subscribe} from './internal/subscribe'
+
+export function useSubscribable<T>(subscribable: Subscribable<T>): SubscribeState<T> {
+  const [state, setState] = useState<SubscribeState<T>>({kind: 'loading'})
+
+  useEffect(() => {
+    setState({kind: 'loading'})
+    const subscription = subscribe(subscribable, {
+      next: value => setState({kind: 'next', value: value as any}),
+      error: err => setState({kind: 'error', err}),
+      complete: () => {},
+    })
+    return () => subscription.unsubscribe()
+  }, [subscribable])
+
+  return state
+}
+
+export type SubscribeState<T> =
+  | {kind: 'loading'}
+  | {kind: 'next'; value: T}
+  | {kind: 'error'; err: any}

--- a/test/Subscribe.Observable.spec.tsx
+++ b/test/Subscribe.Observable.spec.tsx
@@ -1,5 +1,6 @@
-import {shallow, ShallowWrapper} from 'enzyme'
+import {mount, ReactWrapper} from 'enzyme'
 import * as React from 'react'
+import {act} from 'react-dom/test-utils'
 import {Subject} from 'rxjs'
 
 import {Subscribe, SubscribeRenderer} from '~/Subscribe'
@@ -9,7 +10,7 @@ describe('<Subscribe /> (Observable)', () => {
 
   let renderer: {[P in keyof SubscribeRenderer<Value>]: jest.Mock<React.ReactNode>}
   let subject: Subject<Value>
-  let wrapper: ShallowWrapper
+  let wrapper: ReactWrapper
 
   beforeEach(() => {
     renderer = {
@@ -17,8 +18,9 @@ describe('<Subscribe /> (Observable)', () => {
       next: jest.fn().mockImplementation(value => 'next: ' + value.content),
       error: jest.fn().mockReturnValue('error'),
     }
+
     subject = new Subject()
-    wrapper = shallow(<Subscribe to={subject.asObservable()}>{renderer}</Subscribe>)
+    wrapper = mount(<Subscribe to={subject.asObservable()}>{renderer}</Subscribe>)
   })
 
   it('should render the loading state by default', () => {
@@ -30,7 +32,11 @@ describe('<Subscribe /> (Observable)', () => {
   it('should render the next state when the next value arrives', async () => {
     // arrange
     const VALUE = {content: 0}
-    subject.next(VALUE)
+
+    // act
+    act(() => {
+      subject.next(VALUE)
+    })
 
     // assert
     expect(renderer.next).toHaveBeenCalledWith(VALUE)
@@ -38,9 +44,11 @@ describe('<Subscribe /> (Observable)', () => {
   })
 
   it('should render the last value that arrived', async () => {
-    // arrange
-    subject.next({content: 1})
-    subject.next({content: 2})
+    // act
+    act(() => {
+      subject.next({content: 1})
+      subject.next({content: 2})
+    })
 
     // assert
     expect(wrapper.update().text()).toBe('next: 2')
@@ -49,7 +57,11 @@ describe('<Subscribe /> (Observable)', () => {
   it('should render the error state when the observable throws', async () => {
     // arrange
     const ERROR = new Error()
-    subject.error(ERROR)
+
+    // act
+    act(() => {
+      subject.error(ERROR)
+    })
 
     // assert
     expect(renderer.error).toHaveBeenCalledWith(ERROR)

--- a/test/Subscribe.Promise.spec.tsx
+++ b/test/Subscribe.Promise.spec.tsx
@@ -1,5 +1,6 @@
-import {shallow, ShallowWrapper} from 'enzyme'
+import {mount, ReactWrapper} from 'enzyme'
 import * as React from 'react'
+import {act} from 'react-dom/test-utils'
 
 import {Subscribe, SubscribeRenderer} from '~/Subscribe'
 import {Deferred} from './Deferred'
@@ -7,7 +8,7 @@ import {Deferred} from './Deferred'
 describe('<Subscribe /> (Promise)', () => {
   let renderer: {[P in keyof SubscribeRenderer<{}>]: jest.Mock<React.ReactNode>}
   let deferred: Deferred<{}>
-  let wrapper: ShallowWrapper
+  let wrapper: ReactWrapper
 
   beforeEach(() => {
     renderer = {
@@ -16,7 +17,7 @@ describe('<Subscribe /> (Promise)', () => {
       error: jest.fn().mockReturnValue('error'),
     }
     deferred = new Deferred()
-    wrapper = shallow(<Subscribe to={deferred.promise}>{renderer}</Subscribe>)
+    wrapper = mount(<Subscribe to={deferred.promise}>{renderer}</Subscribe>)
   })
 
   it('should render the loading state by default', () => {
@@ -28,8 +29,12 @@ describe('<Subscribe /> (Promise)', () => {
   it('should render the next state when the promise resolves', async () => {
     // arrange
     const VALUE = {}
-    deferred.resolve(VALUE)
-    await deferred
+
+    // act
+    await act(async () => {
+      deferred.resolve(VALUE)
+      await deferred
+    })
 
     // assert
     expect(renderer.next).toHaveBeenCalledWith(VALUE)
@@ -39,8 +44,12 @@ describe('<Subscribe /> (Promise)', () => {
   it('should render the error state when the promise rejects', async () => {
     // arrange
     const ERROR = new Error()
-    deferred.reject(ERROR)
-    await deferred.promise.catch(() => {})
+
+    // act
+    await act(async () => {
+      deferred.reject(ERROR)
+      await deferred.promise.catch(() => {})
+    })
 
     // assert
     expect(renderer.error).toHaveBeenCalledWith(ERROR)

--- a/test/Subscribe.Value.spec.tsx
+++ b/test/Subscribe.Value.spec.tsx
@@ -1,4 +1,4 @@
-import {shallow, ShallowWrapper} from 'enzyme'
+import {mount, ReactWrapper} from 'enzyme'
 import * as React from 'react'
 
 import {Subscribe} from '~/Subscribe'
@@ -7,11 +7,11 @@ describe('<Subscribe /> (Value)', () => {
   const VALUE = {}
 
   let renderer: jest.Mock<React.ReactNode>
-  let wrapper: ShallowWrapper
+  let wrapper: ReactWrapper
 
   beforeEach(() => {
     ;(renderer = jest.fn().mockReturnValue('next')),
-      (wrapper = shallow(<Subscribe to={VALUE}>{renderer}</Subscribe>))
+      (wrapper = mount(<Subscribe to={VALUE}>{renderer}</Subscribe>))
   })
 
   it('should render the next state', () => {


### PR DESCRIPTION
Currently, this library only offers support for render props.
To offer more flexibility, the base features can be implemented using the `useSubscribable` hook.
With this, the `Subscribe` component becomes much shorter.

Additionally, this PR fixes warnings for unsafe lifecycle methods (since no more class components are beeing used).

Even if the API and the behavior of the Subscribe Component stays exactly the same, this is still a breaking change, since we had to bump the Version of React.

(to test hook-based components, enzyme and the development react version had to be bumped and shallow rendering could not be used anymore, since enzyme fires effects only in full rendering)